### PR TITLE
[Payment page] 전체 ui 구현

### DIFF
--- a/korean-air/src/assets/icon/Ellipse.svg
+++ b/korean-air/src/assets/icon/Ellipse.svg
@@ -1,0 +1,3 @@
+<svg width="4" height="4" viewBox="0 0 4 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="2" cy="2" r="2" fill="#CB2B29"/>
+</svg>

--- a/korean-air/src/assets/icon/arrow-up.svg
+++ b/korean-air/src/assets/icon/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 10.6667L12 4M12 4L19 10.6667M12 4V20" stroke="#101010" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/korean-air/src/assets/icon/chevron-down.svg
+++ b/korean-air/src/assets/icon/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 10L12.0008 14.58L17 10" stroke="#101010" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/korean-air/src/assets/icon/ic_check_payment.svg
+++ b/korean-air/src/assets/icon/ic_check_payment.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.8 8.39999L9.64048 15.6L7.2 13.1457" stroke="#0064DE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/korean-air/src/assets/icon/ic_right_nameinfo.svg
+++ b/korean-air/src/assets/icon/ic_right_nameinfo.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.66667 4.66669L10 8.00002L6.66667 11.3334" stroke="#6B7588" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/korean-air/src/assets/icon/ic_right_payment.svg
+++ b/korean-air/src/assets/icon/ic_right_payment.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 7L15 12L10 17" stroke="#101010" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/korean-air/src/assets/icon/ic_up_payment.svg
+++ b/korean-air/src/assets/icon/ic_up_payment.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 14.5834L12.0008 10L17 14.5834" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/korean-air/src/assets/icon/payment_checkbox.svg
+++ b/korean-air/src/assets/icon/payment_checkbox.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 20C5.34315 20 4 18.6569 4 17V6.99998C4 5.34314 5.34315 4 7 4H17C18.6569 4 20 5.34314 20 6.99998L20 17C20 18.6569 18.6569 20 17 20H7Z" fill="#00256C"/>
+<path d="M15 9.99997L10.5253 13.9999L9 12.6365M20 6.99998L20 17C20 18.6569 18.6569 20 17 20H7C5.34315 20 4 18.6569 4 17V6.99998C4 5.34314 5.34315 4 7 4H17C18.6569 4 20 5.34314 20 6.99998Z" stroke="#00256C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 10L10.5253 14L9 12.6365" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/korean-air/src/assets/index.ts
+++ b/korean-air/src/assets/index.ts
@@ -63,4 +63,5 @@ export {
   Ellipse,
   IcRightNameInfo,
   IcUpPayment,
+  ChevronDown,
 };

--- a/korean-air/src/assets/index.ts
+++ b/korean-air/src/assets/index.ts
@@ -25,6 +25,8 @@ import IcPaymentShare from "./icon/ic_payment__share.svg?react";
 import IcPaymentSave from "./icon/ic_payment_save.svg?react";
 import IcPaymentShotarrow from "./icon/ic_payment_shotarrow.svg?react";
 import LogoJinair from "./icon/logo_jinair.svg?react";
+import IcRightPayment from "./icon/ic_right_payment.svg?react";
+import Ellipse from "./icon/Ellipse.svg?react";
 export {
   IcCalendar,
   IcHelp,
@@ -53,4 +55,6 @@ export {
   IcPaymentSave,
   IcPaymentShotarrow,
   LogoJinair,
+  IcRightPayment,
+  Ellipse,
 };

--- a/korean-air/src/assets/index.ts
+++ b/korean-air/src/assets/index.ts
@@ -27,6 +27,10 @@ import IcPaymentShotarrow from "./icon/ic_payment_shotarrow.svg?react";
 import LogoJinair from "./icon/logo_jinair.svg?react";
 import IcRightPayment from "./icon/ic_right_payment.svg?react";
 import Ellipse from "./icon/Ellipse.svg?react";
+import IcRightNameInfo from "./icon/ic_right_nameinfo.svg?react";
+import IcUpPayment from "./icon/ic_up_payment.svg?react";
+import ChevronDown from "./icon/chevron-down.svg?react";
+
 export {
   IcCalendar,
   IcHelp,
@@ -57,4 +61,6 @@ export {
   LogoJinair,
   IcRightPayment,
   Ellipse,
+  IcRightNameInfo,
+  IcUpPayment,
 };

--- a/korean-air/src/assets/index.ts
+++ b/korean-air/src/assets/index.ts
@@ -30,7 +30,9 @@ import Ellipse from "./icon/Ellipse.svg?react";
 import IcRightNameInfo from "./icon/ic_right_nameinfo.svg?react";
 import IcUpPayment from "./icon/ic_up_payment.svg?react";
 import ChevronDown from "./icon/chevron-down.svg?react";
-
+import IcCheckPayment from "./icon/ic_check_payment.svg?react";
+import PaymentCheck from "./icon/payment_checkbox.svg?react";
+import ArrowUp from "./icon/arrow-up.svg?react";
 export {
   IcCalendar,
   IcHelp,
@@ -64,4 +66,7 @@ export {
   IcRightNameInfo,
   IcUpPayment,
   ChevronDown,
+  IcCheckPayment,
+  PaymentCheck,
+  ArrowUp,
 };

--- a/korean-air/src/components/@common/FlightLayout.tsx
+++ b/korean-air/src/components/@common/FlightLayout.tsx
@@ -80,9 +80,3 @@ const BackgroundPayment = styled.div`
   width: 100%;
   height: 6.2rem;
 `;
-
-const IcDownIcon = styled.div`
-  background: url(${IcDownPayment});
-  width: 2.4rem;
-  height: 2.4rem;
-`;

--- a/korean-air/src/components/@common/Footer.tsx
+++ b/korean-air/src/components/@common/Footer.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import styled from "styled-components";
+import theme from "../../styles/theme";
+
+const Footer = () => {
+  return (
+    <Wrapper>
+      <FinalPayment>
+        최종 결제 금액
+        <PaymentDetail>58,300원</PaymentDetail>
+      </FinalPayment>
+
+      <FinalPayBtn type="button">
+        <Reservation>예약하기</Reservation>
+      </FinalPayBtn>
+    </Wrapper>
+  );
+};
+
+export default Footer;
+
+const Wrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 11.4rem;
+  padding: 2rem;
+  position: fixed;
+  bottom: 0;
+  justify-content: space-between;
+  flex-shrink: 0;
+  box-shadow: 0rem -2rem 2rem 0.3rem rgba(107, 117, 136, 0.1);
+`;
+
+const FinalPayment = styled.p`
+  display: flex;
+  justify-content: space-between;
+  color: ${theme.colors.black};
+  ${theme.fonts.body_bold_12}
+`;
+
+const PaymentDetail = styled.p`
+  color: ${theme.colors.navy};
+  text-align: right;
+  ${theme.fonts.body_extrabold_14}
+`;
+
+const FinalPayBtn = styled.button`
+  display: flex;
+  /* width: 343px; */
+  padding: 1.4rem 13.9rem;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  border-radius: 1rem;
+  border: 0.1rem solid ${theme.colors.navy};
+  background: ${theme.colors.navy};
+`;
+
+const Reservation = styled.p`
+  color: ${theme.colors.white};
+  ${theme.fonts.body_bold_14}
+`;

--- a/korean-air/src/components/@common/Footer.tsx
+++ b/korean-air/src/components/@common/Footer.tsx
@@ -22,7 +22,6 @@ export default Footer;
 const Wrapper = styled.section`
   display: flex;
   flex-direction: column;
-  width: 100%;
   height: 11.4rem;
   padding: 2rem;
   position: fixed;
@@ -30,6 +29,7 @@ const Wrapper = styled.section`
   justify-content: space-between;
   flex-shrink: 0;
   box-shadow: 0rem -2rem 2rem 0.3rem rgba(107, 117, 136, 0.1);
+  background-color: ${theme.colors.white};
 `;
 
 const FinalPayment = styled.p`

--- a/korean-air/src/components/@common/Footer.tsx
+++ b/korean-air/src/components/@common/Footer.tsx
@@ -47,7 +47,6 @@ const PaymentDetail = styled.p`
 
 const FinalPayBtn = styled.button`
   display: flex;
-  /* width: 343px; */
   padding: 1.4rem 13.9rem;
   justify-content: center;
   align-items: center;

--- a/korean-air/src/components/paymentPage/CardPersonal.tsx
+++ b/korean-air/src/components/paymentPage/CardPersonal.tsx
@@ -1,0 +1,289 @@
+import React from "react";
+import styled from "styled-components";
+import theme from "../../styles/theme";
+import {
+  ArrowUp,
+  ChevronDown,
+  Ellipse,
+  IcCheckPayment,
+  IcUpPayment,
+  PaymentCheck,
+} from "../../assets";
+
+const CardPersonal = () => {
+  return (
+    <Layout>
+      <InsideLayout>
+        <div>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                승객 선택
+                <CommonBlack>정가윤</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                국적
+                <Ellipse />
+                <CommonBlack>대한민국</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                승객 성
+                <Ellipse />
+                <CommonBlack>정</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                승객 이름
+                <Ellipse />
+                <CommonBlack>가윤</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <CommonLayout>
+            <GenderDiv>
+              <GenderInsideLayout>
+                <span>남자</span>
+              </GenderInsideLayout>
+              <GenderInsideLayoutBlue>
+                <span>여자</span>
+                <IcCheckPayment />
+              </GenderInsideLayoutBlue>
+            </GenderDiv>
+          </CommonLayout>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                생년월일(YYYY.MM.DD)
+                <Ellipse />
+                <CommonBlack>2002.09.14.</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                적립 항공사
+                <Ellipse />
+                <CommonBlack>대한한공</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                가는 여정의 개인 할인
+                <Ellipse />
+                <CommonBlack>선택</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <GrayDiv>
+            <div>
+              <GrayTitle>
+                오는 여정의 개인 할인
+                <Ellipse />
+                <CommonBlack>선택</CommonBlack>
+              </GrayTitle>
+              <ChevronDown />
+            </div>
+          </GrayDiv>
+          <AgreeLayout>
+            <PaymentCheck />
+            <span>국적 정보를 회원정보에 업데이트 하는 것을 동의합니다.</span>
+          </AgreeLayout>
+          <ConfirmBtn type="button">
+            <ConfirmLetter>확인</ConfirmLetter>
+          </ConfirmBtn>
+          <ArrowUpContainer>
+            <ArrowUp />
+          </ArrowUpContainer>
+        </div>
+        <PhoneLayout>
+          <PhoneInfo>연락처 정보</PhoneInfo>
+        </PhoneLayout>
+      </InsideLayout>
+    </Layout>
+  );
+};
+
+export default CardPersonal;
+
+const Layout = styled.section`
+  display: flex;
+  width: 100%;
+  padding: 2rem;
+
+  & > span {
+    color: ${theme.colors.black};
+    ${theme.fonts.body_medium_14};
+  }
+`;
+
+const InsideLayout = styled.div`
+  width: 100%;
+  /* height: 120.4rem; */
+  background-color: ${theme.colors.white};
+  border-radius: 1rem;
+
+  & > div {
+    display: flex;
+    flex-direction: column;
+    border: 0.1rem solid ${theme.colors.grey_4};
+    border-radius: 1rem;
+  }
+`;
+
+const CommonBlack = styled.p`
+  color: ${theme.colors.black};
+  ${theme.fonts.body_extrabold_16};
+  margin-top: 0.2rem;
+  width: 13rem;
+  justify-content: center;
+  align-items: center;
+`;
+
+const GrayDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1rem;
+  padding: 2rem;
+  gap: 0.4rem;
+
+  & > div {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    height: 3.4rem;
+    border-bottom: 0.1rem solid ${theme.colors.black};
+  }
+`;
+
+const GenderInsideLayout = styled.div`
+  display: flex;
+  padding: 2rem;
+  align-items: center;
+  width: 45%;
+  height: 100%;
+  border: 0.1rem solid ${theme.colors.grey_2};
+`;
+
+const GenderInsideLayoutBlue = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 2rem;
+  align-items: center;
+  width: 45%;
+  height: 100%;
+  border: 0.1rem solid ${theme.colors.grey_2};
+  color: ${theme.colors.blue};
+`;
+
+const GrayTitle = styled.p`
+  color: ${theme.colors.grey_3};
+  ${theme.fonts.body_medium_12};
+  /* margin-bottom: 4rem; */
+`;
+
+const CommonLayout = styled.div`
+  display: flex;
+  justify-content: space-around;
+  height: 7.5rem;
+  flex-shrink: 0;
+  margin: 1rem;
+  padding: 2rem;
+`;
+
+const GenderDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  height: 4.4rem;
+`;
+
+const AgreeLayout = styled.section`
+  display: inline-flex;
+  width: 100%;
+  height: 3rem;
+  padding: 1.7rem;
+  align-items: center;
+  gap: 0.4rem;
+
+  & > span {
+    color: ${theme.colors.black};
+    ${theme.fonts.body_medium_12};
+  }
+`;
+
+const ConfirmBtn = styled.button`
+  display: flex;
+  width: 10.8rem;
+  height: 3.8rem;
+  padding: 1rem;
+  justify-content: center;
+  align-items: center;
+  margin-left: 20rem;
+  margin-top: 2.5rem;
+  gap: 1rem;
+  flex-shrink: 0;
+  border-radius: 0.9rem;
+  border: 0.1rem solid ${theme.colors.navy};
+  background: ${theme.colors.navy};
+`;
+
+const ConfirmLetter = styled.p`
+  color: ${theme.colors.white};
+  ${theme.fonts.body_medium_14};
+`;
+
+const ArrowUpContainer = styled.div`
+  display: flex;
+  width: 4.6rem;
+  height: 4.6rem;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  background-color: pink;
+  float: right;
+  border-radius: 5.5rem;
+  border: 0.1rem solid ${theme.colors.grey_5};
+  background: ${theme.colors.white};
+  box-shadow: 0rem 0rem 1rem 0rem rgba(107, 117, 136, 0.2);
+`;
+
+const PhoneLayout = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 5.8rem;
+  padding: 2rem;
+  /* margin-top: 3rem; */
+  flex-shrink: 0;
+  border-radius: 1rem;
+  border: 0.1rem solid ${theme.colors.grey_4};
+`;
+
+const PhoneInfo = styled.p`
+  color: ${theme.colors.black};
+  ${theme.fonts.body_bold_14}
+`;

--- a/korean-air/src/components/paymentPage/CardPersonal.tsx
+++ b/korean-air/src/components/paymentPage/CardPersonal.tsx
@@ -274,6 +274,7 @@ const PhoneLayout = styled.div`
   align-items: center;
   width: 100%;
   height: 5.8rem;
+  margin-top: 1rem;
   padding: 2rem;
   flex-shrink: 0;
   border-radius: 1rem;

--- a/korean-air/src/components/paymentPage/CardPersonal.tsx
+++ b/korean-air/src/components/paymentPage/CardPersonal.tsx
@@ -139,7 +139,6 @@ const Layout = styled.section`
 
 const InsideLayout = styled.div`
   width: 100%;
-  /* height: 120.4rem; */
   background-color: ${theme.colors.white};
   border-radius: 1rem;
 
@@ -201,7 +200,6 @@ const GenderInsideLayoutBlue = styled.div`
 const GrayTitle = styled.p`
   color: ${theme.colors.grey_3};
   ${theme.fonts.body_medium_12};
-  /* margin-bottom: 4rem; */
 `;
 
 const CommonLayout = styled.div`
@@ -277,7 +275,6 @@ const PhoneLayout = styled.div`
   width: 100%;
   height: 5.8rem;
   padding: 2rem;
-  /* margin-top: 3rem; */
   flex-shrink: 0;
   border-radius: 1rem;
   border: 0.1rem solid ${theme.colors.grey_4};

--- a/korean-air/src/components/paymentPage/Journey.tsx
+++ b/korean-air/src/components/paymentPage/Journey.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import theme from "../../styles/theme";
 import { IcPaymentShotarrow, IcRightPayment, LogoJinair } from "../../assets";
-import { PASSENGER_INFO } from "../../constants/constant";
 
 const Journey = () => {
   return (

--- a/korean-air/src/components/paymentPage/Journey.tsx
+++ b/korean-air/src/components/paymentPage/Journey.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 import theme from "../../styles/theme";
-import { IcPaymentShotarrow, LogoJinair } from "../../assets";
+import { IcPaymentShotarrow, IcRightPayment, LogoJinair } from "../../assets";
+import { PASSENGER_INFO } from "../../constants/constant";
 
 const Journey = () => {
   return (
@@ -14,10 +15,11 @@ const Journey = () => {
           <DepartureLayout>
             <EnglishTitle>GMP</EnglishTitle>
             <EnglishSubTitle>서울/김포</EnglishSubTitle>
-            <IcShotarrowIcon />
+            <IcPaymentShotarrow />
             <EnglishTitle>CJU</EnglishTitle>
             <EnglishSubTitle>제주</EnglishSubTitle>
           </DepartureLayout>
+          <IcRightPayment />
         </DetailInfoLayout>
         <FlightTime>06:05</FlightTime>
         <FlightTime>07:15</FlightTime>
@@ -27,6 +29,23 @@ const Journey = () => {
           <JinairTitle>진에어 운항</JinairTitle>
           <JinairTitle>일반석(S)</JinairTitle>
         </TicketLayout>
+      </DepartInfo>
+
+      <DepartInfo>
+        <Title>오는 편</Title>
+        <Date>2023년 12월 9일 (수)</Date>
+        <DetailInfoLayout>
+          <DepartureLayout>
+            <EnglishTitle>CJU</EnglishTitle>
+            <EnglishSubTitle>제주</EnglishSubTitle>
+            <IcPaymentShotarrow />
+            <EnglishTitle>GMP</EnglishTitle>
+            <EnglishSubTitle>서울/김포</EnglishSubTitle>
+          </DepartureLayout>
+          <IcRightPayment />
+        </DetailInfoLayout>
+        <FlightTime>06:05</FlightTime>
+        <FlightTime>07:15</FlightTime>
       </DepartInfo>
     </Layout>
   );
@@ -69,8 +88,9 @@ const Date = styled.p`
 `;
 
 const DetailInfoLayout = styled.div`
+  width: 100%;
   display: inline-flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   gap: 1rem;
 `;

--- a/korean-air/src/components/paymentPage/Journey.tsx
+++ b/korean-air/src/components/paymentPage/Journey.tsx
@@ -57,18 +57,17 @@ const Layout = styled.section`
   padding: 2rem;
   flex-shrink: 0;
 `;
-// body extrabold 20이 없어 ㅠㅠ TODO
+
 const JouneyTitle = styled.p`
-  ${theme.fonts.body_extrabold_16};
+  ${theme.fonts.body_extrabold_20};
   color: ${theme.colors.navy};
 `;
 
-//TODO var 물어보기 (theme)
 const DepartInfo = styled.div`
   height: 16.6rem;
   flex-shrink: 0;
   border-radius: 10px;
-  border: 0.1rem solid var(--grey_4, #c7c9d9);
+  border: 0.1rem solid ${theme.colors.grey_4};
   padding: 0.6rem;
   margin: 1rem;
 `;
@@ -113,12 +112,6 @@ const EnglishTitle = styled.p`
 const EnglishSubTitle = styled.p`
   color: ${theme.colors.black};
   ${theme.fonts.body_regular_12};
-`;
-
-const IcShotarrowIcon = styled.div`
-  background: url(${IcPaymentShotarrow});
-  width: 2.9rem;
-  height: 0.9rem;
 `;
 
 const FlightTime = styled.p`

--- a/korean-air/src/components/paymentPage/UserInfo.tsx
+++ b/korean-air/src/components/paymentPage/UserInfo.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import theme from "../../styles/theme";
 import { Ellipse, IcRightNameInfo } from "../../assets";
-import CardPersonal from "./CardPersonal";
 
 const UserInfo = () => {
   return (
@@ -25,9 +24,6 @@ const UserInfo = () => {
         <Description>성명 입력 안내</Description>
         <IcRightNameInfo />
       </NameInput>
-      {/* <CustomerLayout>
-          <BgBlue></BgBlue>
-        </CustomerLayout> */}
     </Wrapper>
   );
 };
@@ -85,16 +81,4 @@ const NameInput = styled.div`
   gap: 0.5rem;
   border-radius: 0.6rem;
   border: 0.1rem solid var(--grey_2, #6b7588);
-`;
-
-const CustomerLayout = styled.section`
-  height: 120.4rem;
-  border-radius: 10px;
-  border: 0.1rem solid ${theme.colors.grey_4};
-`;
-
-const BgBlue = styled.div`
-  width: 100%;
-  height: 5.8rem;
-  background-color: ${theme.colors.navy};
 `;

--- a/korean-air/src/components/paymentPage/UserInfo.tsx
+++ b/korean-air/src/components/paymentPage/UserInfo.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import styled from "styled-components";
+import theme from "../../styles/theme";
+import { Ellipse, IcRightNameInfo } from "../../assets";
+import CardPersonal from "./CardPersonal";
+
+const UserInfo = () => {
+  return (
+    <Wrapper>
+      <div>
+        <UserInfoTitle>승객 정보</UserInfoTitle>
+        <Require>
+          [<Ellipse /> 는 필수 입력 사항입니다 ]
+        </Require>
+      </div>
+      <section>
+        <Description>
+          예약 후 변경은 <span>불가</span> 하오니 탑승 시 제시할{" "}
+          <span>신분증에 기재된 성명과 언어</span>가 정확히 일치하는지
+          확인하시기 바랍니다. 발음상 변화가 없는 단순 영문 성명 철자변경의 경우
+          로그인한 본인에 한해 <span> 변경하기</span>를 이용하시기 바랍니다
+        </Description>
+      </section>
+      <NameInput>
+        <Description>성명 입력 안내</Description>
+        <IcRightNameInfo />
+      </NameInput>
+      {/* <CustomerLayout>
+          <BgBlue></BgBlue>
+        </CustomerLayout> */}
+    </Wrapper>
+  );
+};
+
+export default UserInfo;
+
+const Wrapper = styled.section`
+  width: 100%;
+  height: 21.3rem;
+  padding: 2rem;
+
+  & > div {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  & > section {
+    display: flex;
+    width: 100%;
+    padding: 2rem;
+    height: 12.8rem;
+    justify-content: center;
+    align-items: center;
+    flex-shrink: 0;
+    border-radius: 1.581rem;
+    background: ${theme.colors.blue_5};
+  }
+`;
+
+const UserInfoTitle = styled.p`
+  color: ${theme.colors.navy};
+  ${theme.fonts.body_extrabold_20};
+`;
+
+const Require = styled.p`
+  color: ${theme.colors.grey_3};
+  ${theme.fonts.body_medium_12}
+`;
+
+const Description = styled.p`
+  color: ${theme.colors.grey_2};
+  ${theme.fonts.body_medium_12};
+
+  & > span {
+    color: ${theme.colors.blue};
+  }
+`;
+
+const NameInput = styled.div`
+  display: flex;
+  padding: 1rem 0rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.6rem;
+  border: 0.1rem solid var(--grey_2, #6b7588);
+`;
+
+const CustomerLayout = styled.section`
+  height: 120.4rem;
+  border-radius: 10px;
+  border: 0.1rem solid ${theme.colors.grey_4};
+`;
+
+const BgBlue = styled.div`
+  width: 100%;
+  height: 5.8rem;
+  background-color: ${theme.colors.navy};
+`;

--- a/korean-air/src/pages/PaymentPage.tsx
+++ b/korean-air/src/pages/PaymentPage.tsx
@@ -6,18 +6,24 @@ import Header from "../components/@common/Header";
 import UserInfo from "../components/paymentPage/UserInfo";
 import CardPersonal from "../components/paymentPage/CardPersonal";
 import Footer from "../components/@common/Footer";
+import styled from "styled-components";
 
 const PaymentPage = () => {
   return (
-    <>
+    <Wrapper>
       <Header />
       <PaymentInfo />
       <Journey />
       <UserInfo />
       <CardPersonal />
       <Footer />
-    </>
+    </Wrapper>
   );
 };
 
 export default PaymentPage;
+
+const Wrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+`;

--- a/korean-air/src/pages/PaymentPage.tsx
+++ b/korean-air/src/pages/PaymentPage.tsx
@@ -3,6 +3,9 @@ import PaymentInfo from "../components/paymentPage/PaymentInfo";
 import IconLayout from "../components/paymentPage/IconLayout";
 import Journey from "../components/paymentPage/Journey";
 import Header from "../components/@common/Header";
+import UserInfo from "../components/paymentPage/UserInfo";
+import CardPersonal from "../components/paymentPage/CardPersonal";
+import Footer from "../components/@common/Footer";
 
 const PaymentPage = () => {
   return (
@@ -10,6 +13,9 @@ const PaymentPage = () => {
       <Header />
       <PaymentInfo />
       <Journey />
+      <UserInfo />
+      <CardPersonal />
+      <Footer />
     </>
   );
 };

--- a/korean-air/src/pages/PaymentPage.tsx
+++ b/korean-air/src/pages/PaymentPage.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import PaymentInfo from "../components/paymentPage/PaymentInfo";
 import IconLayout from "../components/paymentPage/IconLayout";
 import Journey from "../components/paymentPage/Journey";
+import Header from "../components/@common/Header";
 
 const PaymentPage = () => {
   return (
     <>
+      <Header />
       <PaymentInfo />
       <Journey />
     </>

--- a/korean-air/src/styles/theme.ts
+++ b/korean-air/src/styles/theme.ts
@@ -133,6 +133,16 @@ const fonts = {
     line-height: 140%;
     letter-spacing: 0.02rem;
   `,
+
+  body_extrabold_20: css`
+    font-family: "Pretendard";
+    font-size: 2em;
+    font-style: normal;
+    font-weight: 800;
+    line-height: 148.02%;
+    letter-spacing: 0.08rem;
+  `,
+
   title_bold_18: css`
     font-family: "Pretendard";
     font-size: 1.8rem;

--- a/korean-air/src/styles/theme.ts
+++ b/korean-air/src/styles/theme.ts
@@ -144,7 +144,7 @@ const fonts = {
 
   body_extrabold_20: css`
     font-family: "Pretendard";
-    font-size: 2em;
+    font-size: 2rem;
     font-style: normal;
     font-weight: 800;
     line-height: 148.02%;

--- a/korean-air/src/styles/theme.ts
+++ b/korean-air/src/styles/theme.ts
@@ -61,6 +61,14 @@ const fonts = {
     line-height: 140%;
     letter-spacing: 0.02rem;
   `,
+  body_medium_14: css`
+    font-family: "Pretendard";
+    font-size: 1.4rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 148%;
+    letter-spacing: 0.056rem;
+  `,
   body_semibold_12: css`
     font-family: "Pretendard";
     font-size: 1.2rem;


### PR DESCRIPTION
## 🔥 Related Issues

resolved #11 

## ✈️ 작업 내용

<!-- 과제에서 작성했던 것 처럼, 자신이 구현한 기능 리스트업 -->

 ic_allup
 payment_information
 payment_save
 payment_share
 payment_journey
 payment_customer
 payment_phone
 payment_bottom

## ✅ PR Point

컴포넌트는 아래와 같이 나누었습니다. 

```javascript
const PaymentPage = () => {
  return (
    <>
      <Header />
      <PaymentInfo />
      <Journey />
      <UserInfo />
      <CardPersonal />
      <Footer />
    </>
  );
};

export default PaymentPage;
```

공통으로 쓰일 것 같은 컴포넌트는 @common에 빼두었습니다.
예를들어 FlightLayout 컴포넌트와 Footer 컴포넌트 등.

승희 퍼블리싱 코드 보고 깔끔한 것에 감명받아서 최대한 따라해보려고 했는데 작업속도가 되게 늦어지더라구요. 

그래서 시간에 촉박한 이슈로 결국 빨리빨리 탁탁탁 하게되었습니다 ㅠ

결과물 보니까 구체적인 위치가 굉장히 맘에 안드네요.

## 😡 Trouble Shooting


컴포넌트가 CardPersonl과 Footer가 있는데, 
Footer를 구현하던 중, div 태그 안에 section 태그가 포함되어 있는데, 
영역 상 계속 section 태그가 div 태그 밖으로 표시가 되더라구요??

승희가 div에 height 값이 설정 되어 있어서 border를 주고 싶으면 div 안에 div를 또 만들고 height 값 지우면 해결될 것 이라고 알려줘서 덕분에 해결했습니다. 

```javascipt
const InsideLayout = styled.div`
  width: 100%;
  background-color: ${theme.colors.white};
  border-radius: 1rem;

  & > div {
    display: flex;
    flex-direction: column;
    border: 0.1rem solid ${theme.colors.grey_4};
    border-radius: 1rem;
  }
`;
```
이렇게 insideLayout 안에 div를 주고 height를 없애서 해결하였습니다.


## 👀 구현 결과물
<img width="378" alt="스크린샷 2023-11-29 오후 4 53 06" src="https://github.com/SOPT-33th-JointSeminar-3/Client-Web/assets/126966681/4017447a-3e84-4404-adc0-f0f8df72dbe1">

<img width="376" alt="스크린샷 2023-11-29 오후 4 53 19" src="https://github.com/SOPT-33th-JointSeminar-3/Client-Web/assets/126966681/0eba7fda-3f42-436b-ae7e-0f154f7d208c">

<img width="374" alt="스크린샷 2023-11-29 오후 4 53 32" src="https://github.com/SOPT-33th-JointSeminar-3/Client-Web/assets/126966681/f3b3c07c-ef34-4d4a-b768-a488f238e171">






<!-- 구현 결과를 보여주는 스크린샷, 혹은 동영상 첨부 (필요한 경우만 작성하고 없으면 지우기) -->

## 📚 Reference

<!-- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기) -->
