### PR TITLE
[MainPage] 게시물 불러오기 api

### DIFF
--- a/korean-air/src/api/axiosInstance.ts
+++ b/korean-air/src/api/axiosInstance.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const axiosInstance = axios.create({
-  baseURL: "http://13.125.7.142:8080/",
+  baseURL: "https://www.dosopt-cds-web3.o-r.kr/",
   headers: { "Content-Type": "application/json" },
 });
 

--- a/korean-air/src/api/axiosInstance.ts
+++ b/korean-air/src/api/axiosInstance.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const axiosInstance = axios.create({
+  baseURL: "http://13.125.7.142:8080/",
+  headers: { "Content-Type": "application/json" },
+});
+
+export default axiosInstance;

--- a/korean-air/src/api/getHomePosts.ts
+++ b/korean-air/src/api/getHomePosts.ts
@@ -1,7 +1,10 @@
 import { useEffect } from "react";
 import axiosInstance from "./axiosInstance";
+import { PostItem } from "../components/mainPage/Notice";
 
-const getHomePosts = (setResponse) => {
+const getHomePosts = (
+  setResponse: React.Dispatch<React.SetStateAction<PostItem[]>>,
+) => {
   const fetchData = async () => {
     try {
       const res = await axiosInstance.get("api/posts");

--- a/korean-air/src/api/getHomePosts.ts
+++ b/korean-air/src/api/getHomePosts.ts
@@ -1,12 +1,18 @@
+import { useEffect } from "react";
 import axiosInstance from "./axiosInstance";
 
-const getHomePosts = async () => {
-  try {
-    const res = await axiosInstance.get("api/posts");
-    return res.data;
-  } catch (error) {
-    console.log(error);
-  }
+const getHomePosts = (setResponse) => {
+  const fetchData = async () => {
+    try {
+      const res = await axiosInstance.get("api/posts");
+      setResponse(res.data.data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  useEffect(() => {
+    fetchData();
+  }, []);
 };
 
 export default getHomePosts;

--- a/korean-air/src/api/getHomePosts.ts
+++ b/korean-air/src/api/getHomePosts.ts
@@ -1,0 +1,12 @@
+import axiosInstance from "./axiosInstance";
+
+const getHomePosts = async () => {
+  try {
+    const res = await axiosInstance.get("api/posts");
+    return res.data;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default getHomePosts;

--- a/korean-air/src/components/mainPage/Notice.tsx
+++ b/korean-air/src/components/mainPage/Notice.tsx
@@ -1,22 +1,26 @@
 import styled from "styled-components";
-import { NOTICE_DATE, NOTICE_TITLE } from "../../constants/constant";
-import { useEffect } from "react";
+import { useState } from "react";
 import getHomePosts from "../../api/getHomePosts";
+
+interface PostItem {
+  id: number;
+  title: string;
+  date: string;
+}
 export const Notice = () => {
-  useEffect(() => {
-    const data = getHomePosts();
-    console.log(data);
-  }, []);
+  const [response, setResponse] = useState([]);
+  getHomePosts(setResponse);
+  console.log(response);
   return (
     <NoticeBox>
       <Header>
         <Title>알려드립니다</Title>
         <More>See More</More>
       </Header>
-      {NOTICE_TITLE.map((title, index) => (
-        <NoticeContent key={title}>
-          <NoticeTitle>{title}</NoticeTitle>
-          <NoticeDate>{NOTICE_DATE[index]}</NoticeDate>
+      {response.map((item: PostItem) => (
+        <NoticeContent key={item.id}>
+          <NoticeTitle>{item.title}</NoticeTitle>
+          <NoticeDate>{item.date}</NoticeDate>
         </NoticeContent>
       ))}
     </NoticeBox>

--- a/korean-air/src/components/mainPage/Notice.tsx
+++ b/korean-air/src/components/mainPage/Notice.tsx
@@ -1,6 +1,12 @@
 import styled from "styled-components";
 import { NOTICE_DATE, NOTICE_TITLE } from "../../constants/constant";
+import { useEffect } from "react";
+import getHomePosts from "../../api/getHomePosts";
 export const Notice = () => {
+  useEffect(() => {
+    const data = getHomePosts();
+    console.log(data);
+  }, []);
   return (
     <NoticeBox>
       <Header>

--- a/korean-air/src/components/mainPage/Notice.tsx
+++ b/korean-air/src/components/mainPage/Notice.tsx
@@ -2,13 +2,13 @@ import styled from "styled-components";
 import { useState } from "react";
 import getHomePosts from "../../api/getHomePosts";
 
-interface PostItem {
+export interface PostItem {
   id: number;
   title: string;
   date: string;
 }
 export const Notice = () => {
-  const [response, setResponse] = useState([]);
+  const [response, setResponse] = useState<PostItem[]>([]);
   getHomePosts(setResponse);
   console.log(response);
   return (

--- a/korean-air/src/constants/constant.ts
+++ b/korean-air/src/constants/constant.ts
@@ -1,9 +1,0 @@
-const NOTICE_TITLE = [
-  "국내선 유류할증료 (2023년 12월)",
-  "Rentalcars.com 제휴 서비스 일시 중단",
-  "마일리지 몰 KAL스토어 연말 할인 프로모션",
-  "사전 좌석 배정 서비스 신청 온라인 전환",
-];
-const NOTICE_DATE = ["2023.11.02", "2023.11.01", "2023.11.01", "2023.10.31"];
-
-export { NOTICE_TITLE, NOTICE_DATE };

--- a/korean-air/src/main.tsx
+++ b/korean-air/src/main.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
-import '../index.css';
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "../index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <>
     <App />
-  </React.StrictMode>
+  </>,
 );


### PR DESCRIPTION
## 🔥 Related Issues

resolved #30 

## ✈️ 작업 내용

- [x] api 연결해서 게시물 정보 가져왔습니다.
- [x] 가져온 게시물 정보를 화면에 보여주었습니다.(map 이용)

## ✅ PR Point
response의 타입 설정을 위해 인터페이스를 사용했습니다.
```javascript
interface PostItem {
  id: number;
  title: string;
  date: string;
}
const [response, setResponse] = useState([]);

{response.map((item: PostItem) => (
        <NoticeContent key={item.id}>
          <NoticeTitle>{item.title}</NoticeTitle>
          <NoticeDate>{item.date}</NoticeDate>
        </NoticeContent>
      ))}
```
<img width="796" alt="스크린샷 2023-11-30 오전 11 21 15" src="https://github.com/SOPT-33th-JointSeminar-3/Client-Web/assets/102568726/3ee14ae8-cc4f-4e36-8092-0d9311b9942f">
타입을 다른 set함수 타입 지정해주는 것처럼 했는데 그렇게 했을 때는 아예 정보가 안받아와져서 빨간 줄인 채로 ,,놔두었는데 혹시 방법을 아신다면 ㅜㅜㅜ 타스 너무 어려워요..

## 😡 Trouble Shooting
- CORS 에러

  <img width="1512" alt="스크린샷 2023-11-30 오전 11 04 21" src="https://github.com/SOPT-33th-JointSeminar-3/Client-Web/assets/102568726/f309e94d-1659-4aa1-8ae8-21e9c7bf3648">

   서버측과 이야기해서 권한 부여받아서 해결했습니다.(승희 오기 전까지 내 문제인줄 알고 혼자 끙끙..)

- 응답이 PROMISE 객체로 오는 걸 처음 접해봤습니다! 승희의 도움으로 해결했지만 이 부분은 더 공부해야 할 것 같습니다..ㅎㅎ


## 👀 구현 결과물
<img width="421" alt="스크린샷 2023-11-30 오전 11 23 44" src="https://github.com/SOPT-33th-JointSeminar-3/Client-Web/assets/102568726/da0618fd-69d1-489b-896b-1a45c3c42a32">


