### PR TITLE
[payment] api 함수 호출 및 상위 컴포넌트에서 데이터 패칭

### DIFF
--- a/korean-air/src/api/getReserve.ts
+++ b/korean-air/src/api/getReserve.ts
@@ -1,0 +1,20 @@
+import axiosInstance from "./axiosInstance";
+
+export const getReserve = async (
+  firstName: string,
+  lastName: string,
+  gender: string,
+  birth: string,
+) => {
+  try {
+    const response = await axiosInstance.post(`api/passenger`, {
+      firstName,
+      lastName,
+      gender,
+      birth,
+    });
+    console.log(response);
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/korean-air/src/pages/PaymentPage.tsx
+++ b/korean-air/src/pages/PaymentPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PaymentInfo from "../components/paymentPage/PaymentInfo";
 import IconLayout from "../components/paymentPage/IconLayout";
 import Journey from "../components/paymentPage/Journey";
@@ -7,8 +7,26 @@ import UserInfo from "../components/paymentPage/UserInfo";
 import CardPersonal from "../components/paymentPage/CardPersonal";
 import Footer from "../components/@common/Footer";
 import styled from "styled-components";
+import { getReserve } from "../api/getReserve";
 
 const PaymentPage = () => {
+  const [firstName, setFirstName] = useState("정");
+  const [lastName, setLastName] = useState("가윤");
+  const [gender, setGenderName] = useState("여자");
+  const [birth, setBirthName] = useState("2002-09-14");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const postData = await getReserve(firstName, lastName, gender, birth);
+
+        console.log(postData);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    fetchData();
+  }, []);
   return (
     <Wrapper>
       <Header />


### PR DESCRIPTION
## 🔥 Related Issues

resolved #47 

## ✈️ 작업 내용

<!-- 과제에서 작성했던 것 처럼, 자신이 구현한 기능 리스트업 -->

- [x] http method가 POST인 api 연결


## ✅ PR Point

api 함수를 하나 만들어 뒀습니다.

```typescript
import axiosInstance from "./axiosInstance";

export const getReserve = async (
  firstName: string,
  lastName: string,
  gender: string,
  birth: string,
) => {
  try {
    const response = await axiosInstance.post(`api/passenger`, {
      firstName,
      lastName,
      gender,
      birth,
    });
    console.log(response);
  } catch (error) {
    console.log(error);
  }
};
```

이제 이를 paymentPage에서 useEffect를 이용하여 호춣해줍니다.
```typescript
useEffect(() => {
    const fetchData = async () => {
      try {
        const postData = await getReserve(firstName, lastName, gender, birth);

        console.log(postData);
      } catch (error) {
        console.log(error);
      }
    };
    fetchData();
  }, []);
```


## 😡 Trouble Shooting

x

## 👀 구현 결과물

![image](https://github.com/SOPT-33th-JointSeminar-3/Client-Web/assets/126966681/d2985171-f663-4b44-9a56-d92405b0ed41)

## 📚 Reference

<!-- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기) -->
